### PR TITLE
Allow specifying the service for group listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can pass a custom path when instantiating the client or via the CLI's `--net
 from sim_api_wrapper import SimApiClient
 
 with SimApiClient() as client:
-    groups = client.list_groups()
+    groups = client.list_groups("AI")
     members = client.get_group_members("pn69ju-ai-c")
     links = client.get_project_institution_links("pn69ju")
     institution = client.get_institution("0000000000E4EE4B")
@@ -60,7 +60,7 @@ structured access to the response payload.
 A small CLI is bundled for quick lookups:
 
 ```bash
-sim-api groups
+sim-api groups AI
 sim-api group-members pn69ju-ai-c
 sim-api project-institution pn69ju
 sim-api institution 0000000000E4EE4B

--- a/src/sim_api_wrapper/cli.py
+++ b/src/sim_api_wrapper/cli.py
@@ -48,7 +48,8 @@ def build_parser() -> argparse.ArgumentParser:
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    subparsers.add_parser("groups", help="List all available project groups.")
+    groups = subparsers.add_parser("groups", help="List all available project groups.")
+    groups.add_argument("service", help="Service identifier, e.g. AI.")
 
     members = subparsers.add_parser("group-members", help="List members of a project group.")
     members.add_argument("group_name", help="Name of the group to inspect.")
@@ -85,7 +86,7 @@ def main(argv: list[str] | None = None) -> int:
         use_netrc=not args.no_netrc,
     ) as client:
         if args.command == "groups":
-            result = client.list_groups()
+            result = client.list_groups(args.service)
         elif args.command == "group-members":
             result = client.get_group_members(args.group_name, solve=args.solve)
         elif args.command == "project-institution":

--- a/src/sim_api_wrapper/client.py
+++ b/src/sim_api_wrapper/client.py
@@ -55,10 +55,11 @@ class SimApiClient(AbstractContextManager["SimApiClient"]):
         self.close()
 
     # -- public API methods -------------------------------------------------------
-    def list_groups(self) -> List[str]:
-        """Return all available project groups."""
+    def list_groups(self, service: str) -> List[str]:
+        """Return all available project groups for the given service."""
 
-        data = self._request_json("GET", "/service/AI/groups")
+        endpoint = f"/service/{service}/groups"
+        data = self._request_json("GET", endpoint)
         if isinstance(data, list):
             return [str(item) for item in data]
         raise SimApiError("Unexpected response payload for groups endpoint")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -47,7 +47,7 @@ def test_list_groups(register_response, client: SimApiClient) -> None:
     url = f"{DEFAULT_BASE_URL}/service/AI/groups"
     register_response(url, json_data=["a1101", "a1101-ai-c"])
 
-    groups = client.list_groups()
+    groups = client.list_groups("AI")
 
     assert groups == ["a1101", "a1101-ai-c"]
 
@@ -187,4 +187,4 @@ def test_error_handling(register_response, client: SimApiClient) -> None:
     )
 
     with pytest.raises(SimApiError):
-        client.list_groups()
+        client.list_groups("AI")


### PR DESCRIPTION
## Summary
- allow selecting a service when retrieving groups via the client
- require the service identifier for the CLI `groups` command
- update documentation and tests to reflect the new argument

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8da47a62c832587d7c67d83d2b1d3