### PR TITLE
Add basic authentication support to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,18 @@ uv pip install -e ".[test]"
 pytest
 ```
 
-The client expects a SIM API token to be stored in an environment file at `~/.simapi.env`.
-Populate it with a `SIMAPI_TOKEN` entry, for example:
+The client expects authentication details to be stored in an environment file at
+`~/.simapi.env`. Populate it with either a bearer token (`SIMAPI_TOKEN`) or username and
+password pair (`SIMAPI_USERNAME` and `SIMAPI_PASSWORD`), for example:
 
 ```bash
-echo "SIMAPI_TOKEN=your_token_here" > ~/.simapi.env
+echo "SIMAPI_USERNAME=your_username" > ~/.simapi.env
+echo "SIMAPI_PASSWORD=your_password" >> ~/.simapi.env
 ```
 
 The file is loaded automatically via [`python-dotenv`](https://github.com/theskumar/python-dotenv).
-You can provide a custom path, disable automatic loading, or pass the token explicitly via the
-CLI options `--env-file`, `--no-env-file`, and `--token`.
+You can provide a custom path, disable automatic loading, or pass the credentials explicitly via
+the CLI options `--env-file`, `--no-env-file`, `--token`, `--username`, and `--password`.
 
 ## Usage
 
@@ -76,8 +78,8 @@ sim-api person 00000000001F17E0
 sim-api user di38qex
 ```
 
-Use `--help` to inspect all options. The CLI accepts `--env-file`, `--no-env-file`, and `--token`
-to control authentication explicitly.
+Use `--help` to inspect all options. The CLI accepts `--env-file`, `--no-env-file`, `--token`,
+`--username`, and `--password` to control authentication explicitly.
 
 ## Extending the client
 

--- a/src/sim_api_wrapper/auth.py
+++ b/src/sim_api_wrapper/auth.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Tuple
 import logging
+import base64
 
 try:  # pragma: no cover - import guard for optional dependency
     from dotenv import load_dotenv
@@ -31,6 +32,8 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_ENV_PATH = Path("~/.simapi.env").expanduser()
 _ENV_VARIABLE = "SIMAPI_TOKEN"
+_USERNAME_VARIABLE = "SIMAPI_USERNAME"
+_PASSWORD_VARIABLE = "SIMAPI_PASSWORD"
 
 
 def load_token_from_env_file(env_path: Optional[str | Path] = None) -> str:
@@ -75,3 +78,55 @@ def build_bearer_auth_header(token: str) -> str:
     if not token:
         raise ValueError("Token must be a non-empty string")
     return f"Bearer {token}"
+
+
+def load_basic_auth_from_env_file(env_path: Optional[str | Path] = None) -> Tuple[str, str]:
+    """Load SIM API basic authentication credentials from a dotenv-style file.
+
+    Parameters
+    ----------
+    env_path:
+        Optional path to the dotenv file. When omitted, ``~/.simapi.env`` is used.
+
+    Returns
+    -------
+    Tuple[str, str]
+        The username and password read from ``SIMAPI_USERNAME`` and
+        ``SIMAPI_PASSWORD``.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the specified dotenv file does not exist.
+    ValueError
+        If either variable is missing or empty in the loaded environment.
+    """
+
+    path = Path(env_path).expanduser() if env_path else _DEFAULT_ENV_PATH
+    if not path.exists():
+        raise FileNotFoundError(f"Environment file not found at {path!s}")
+
+    load_dotenv(path)
+    username = os.getenv(_USERNAME_VARIABLE)
+    password = os.getenv(_PASSWORD_VARIABLE)
+    if not username or not password:
+        raise ValueError(
+            "Environment variables "
+            f"{_USERNAME_VARIABLE} and {_PASSWORD_VARIABLE} must both be set in {path!s}"
+        )
+
+    logger.debug("Loaded SIM API basic auth credentials from %s", path)
+    return username, password
+
+
+def build_basic_auth_header(username: str, password: str) -> str:
+    """Return the HTTP Basic authorization header for the given credentials."""
+
+    if not username:
+        raise ValueError("Username must be a non-empty string")
+    if not password:
+        raise ValueError("Password must be a non-empty string")
+
+    user_pass = f"{username}:{password}".encode("utf-8")
+    encoded = base64.b64encode(user_pass).decode("ascii")
+    return f"Basic {encoded}"

--- a/src/sim_api_wrapper/cli.py
+++ b/src/sim_api_wrapper/cli.py
@@ -27,6 +27,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Interact with the LRZ SIM API.")
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="Override the API base URL.")
     parser.add_argument("--token", default=None, help="SIM API token for authentication.")
+    parser.add_argument("--username", default=None, help="SIM username for basic authentication.")
+    parser.add_argument(
+        "--password",
+        default=None,
+        help="SIM password for basic authentication (use with caution on shared systems).",
+    )
     parser.add_argument(
         "--env-file",
         default=None,
@@ -87,6 +93,8 @@ def main(argv: list[str] | None = None) -> int:
     with SimApiClient(
         base_url=args.base_url,
         token=args.token,
+        username=args.username,
+        password=args.password,
         env_path=args.env_file,
         timeout=args.timeout,
         load_env=not args.no_env_file,

--- a/src/sim_api_wrapper/client.py
+++ b/src/sim_api_wrapper/client.py
@@ -10,7 +10,12 @@ from urllib import error as urllib_error
 from urllib import parse as urllib_parse
 from urllib import request as urllib_request
 
-from .auth import build_bearer_auth_header, load_token_from_env_file
+from .auth import (
+    build_basic_auth_header,
+    build_bearer_auth_header,
+    load_basic_auth_from_env_file,
+    load_token_from_env_file,
+)
 from .exceptions import SimApiError
 from .models import Institution, Person, ProjectInstitutionLink, User
 
@@ -29,6 +34,8 @@ class SimApiClient(AbstractContextManager["SimApiClient"]):
         base_url: str = DEFAULT_BASE_URL,
         timeout: int | float = DEFAULT_TIMEOUT,
         token: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
         env_path: Optional[str] = None,
         load_env: bool = True,
     ) -> None:
@@ -43,6 +50,14 @@ class SimApiClient(AbstractContextManager["SimApiClient"]):
                 self._auth_header = build_bearer_auth_header(token)
             except ValueError as exc:
                 self.logger.debug("Invalid token supplied: %s", exc)
+        elif username or password:
+            if not username or not password:
+                self.logger.debug("Both username and password must be provided for basic auth")
+            else:
+                try:
+                    self._auth_header = build_basic_auth_header(username, password)
+                except ValueError as exc:
+                    self.logger.debug("Invalid basic auth credentials supplied: %s", exc)
         elif load_env or env_path:
             try:
                 env_token = load_token_from_env_file(env_path)
@@ -52,6 +67,17 @@ class SimApiClient(AbstractContextManager["SimApiClient"]):
                 self.logger.debug("Skipping token from environment file: %s", exc)
             else:
                 self._auth_header = build_bearer_auth_header(env_token)
+            if not self._auth_header:
+                try:
+                    env_username, env_password = load_basic_auth_from_env_file(env_path)
+                except FileNotFoundError:
+                    self.logger.debug(
+                        "No environment file found for basic auth; continuing without authentication"
+                    )
+                except ValueError as exc:
+                    self.logger.debug("Skipping basic auth credentials from environment file: %s", exc)
+                else:
+                    self._auth_header = build_basic_auth_header(env_username, env_password)
 
     # -- context manager protocol -------------------------------------------------
     def __enter__(self) -> "SimApiClient":  # pragma: no cover - context convenience

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Tuple
 import pytest
 
 from sim_api_wrapper.client import DEFAULT_BASE_URL, SimApiClient
+from sim_api_wrapper.auth import build_basic_auth_header
 from sim_api_wrapper.exceptions import SimApiError
 
 ResponseTuple = Tuple[int, Dict[str, str], bytes]
@@ -188,3 +189,19 @@ def test_error_handling(register_response, client: SimApiClient) -> None:
 
     with pytest.raises(SimApiError):
         client.list_groups("AI")
+
+
+def test_basic_auth_header_is_sent(monkeypatch: pytest.MonkeyPatch) -> None:
+    observed_headers = {}
+
+    def fake_open(self: SimApiClient, request):
+        observed_headers.update(request.header_items())
+        return 200, {"Content-Type": "application/json"}, b"[]"
+
+    monkeypatch.setattr(SimApiClient, "_open", fake_open)
+
+    with SimApiClient(username="user", password="pass", load_env=False) as api_client:
+        api_client.list_groups("AI")
+
+    header_dict = dict(observed_headers)
+    assert header_dict["Authorization"] == build_basic_auth_header("user", "pass")


### PR DESCRIPTION
## Summary
- allow the client to authenticate with SIM username/password by building a Basic authorization header
- expose CLI switches and documentation for providing credentials explicitly
- add regression coverage ensuring Authorization headers are attached to requests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d98176cd088325935819cca56d754b