### PR TITLE
Add development extra to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ classifiers = [
 test = [
     "pytest>=8.0",
 ]
+dev = [
+    "pytest>=8.0",
+]
 
 [project.scripts]
 sim-api = "sim_api_wrapper.cli:main"


### PR DESCRIPTION
## Summary
- add a `dev` extra to the optional dependency list so editable installs with `[dev]` succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbd21c14cc8325845264eff3ab5a6c