### PR TITLE
Decode escape sequences in CLI separator argument

### DIFF
--- a/src/sim_api_wrapper/cli.py
+++ b/src/sim_api_wrapper/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import codecs
 import logging
 from dataclasses import asdict, is_dataclass
 from typing import Any, Callable
@@ -134,10 +135,11 @@ def main(argv: list[str] | None = None) -> int:
     payload = _prepare_payload(result)
     formatter = _select_formatter(args.format)
     fields = parse_fields(args.fields)
+    separator = _decode_separator(args.sep)
     text = formatter(
         payload,
         fields=fields,
-        separator=args.sep,
+        separator=separator,
         include_header=not args.no_header,
     )
     print(text)
@@ -164,6 +166,15 @@ def _select_formatter(fmt: str) -> Callable[..., str]:
         return mapping[fmt]
     except KeyError:  # pragma: no cover - argparse restricts format
         raise ValueError(f"Unsupported format: {fmt}")
+
+
+def _decode_separator(value: str) -> str:
+    """Interpret escape sequences in separators from CLI arguments."""
+
+    try:
+        return codecs.decode(value, "unicode_escape")
+    except Exception:
+        return value
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+"""Tests for CLI utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from sim_api_wrapper.cli import _decode_separator
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (",", ","),
+        ("\\t", "\t"),
+        ("\\n", "\n"),
+        ("\\x09", "\t"),
+    ],
+)
+def test_decode_separator_handles_escape_sequences(value: str, expected: str) -> None:
+    assert _decode_separator(value) == expected


### PR DESCRIPTION
## Summary
- decode CLI separator arguments using unicode escape sequences so escaped values like ``\t`` work when passed via the shell
- add unit tests covering separator decoding behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbd451b72c8325a5f4891461a67aa8